### PR TITLE
Fix missing variable initialization in HOA gamestart

### DIFF
--- a/nf_base/md/setup_gamestarts_cwir.xml
+++ b/nf_base/md/setup_gamestarts_cwir.xml
@@ -382,6 +382,9 @@
 				<event_cue_signalled cue="md.Setup.GameStart"/>
 			</conditions>
 			<actions>
+				<create_list name="$todo_stations" />
+				<create_list name="$todo_ships" />
+				<!-- UNIVERSE -->
 				<signal_cue cue="md.Setup.Open_Jumpgates_Lib"/> 
 				<signal_cue cue="md.Setup.WeaponTraderBasket3"/>
 				<signal_cue cue="md.Setup.EquipmentTraderBasket2"/>


### PR DESCRIPTION
This fixes an MD error in the HOA gamestart

```
[General] 1.00 ======================================
[=ERROR=] 1.00 Error in MD cue md.Setup_Gamestarts_CWIR.setup_cwir_hoastart: Property lookup failed: $todo_ships
* Expression: $todo_ships
[General] 1.00 ======================================
[General] 1.00 ======================================
[=ERROR=] 1.00 Error in MD cue md.Setup_Gamestarts_CWIR.setup_cwir_hoastart: Evaluated value 'null' is not of type list
* Expression: $todo_ships
[General] 1.00 ======================================
```